### PR TITLE
fix: rewards apr decimals

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@aave/contract-helpers": "1.18.3",
-    "@aave/math-utils": "1.18.3",
+    "@aave/math-utils": "https://github.com/seamless-protocol/aave-utilities#math-utils-dist-v1",
     "@bgd-labs/aave-address-book": "^1.33.0",
     "@emotion/cache": "11.10.3",
     "@emotion/react": "11.10.4",

--- a/src/store/incentiveSlice.ts
+++ b/src/store/incentiveSlice.ts
@@ -63,7 +63,6 @@ const incentiveDataInjectSEAMPriceUSD = (
   ...incentiveData,
   rewardsTokenInformation: incentiveData.rewardsTokenInformation.map((incentive) => ({
     ...incentive,
-    emissionPerSecond: normalizeDecimals(parseFloat(incentive.emissionPerSecond), incentive.rewardTokenDecimals, 18).toString(),  // Hack to normalize to 18 decimals, since Aave math utils has a bug
     rewardPriceFeed:
       SEAM_SYMBOLS.includes(incentive.rewardTokenSymbol)
         ? seamPriceUSD

--- a/src/store/incentiveSlice.ts
+++ b/src/store/incentiveSlice.ts
@@ -36,13 +36,25 @@ const getCoinGeckoSEAMPriceUSD = async (): Promise<string> => {
 
     return (
       parseUnits(price.toString(), PRICE_FEED_DECIMALS).toString() ??
-      parseUnits('9.0', PRICE_FEED_DECIMALS).toString()
+      parseUnits('4.0', PRICE_FEED_DECIMALS).toString()
     );
   } catch (err) {
     console.error('Error: Failed to fetch SEAM price from CoinGecko: ', err);
-    return parseUnits('9.0', PRICE_FEED_DECIMALS).toString();
+    return parseUnits('4.0', PRICE_FEED_DECIMALS).toString();
   }
 };
+
+function normalizeDecimals(
+  value: number,
+  valueDecimals: number,
+  toDecimals: number
+): number {
+  if (valueDecimals <= toDecimals) {
+    return value * 10 ** (toDecimals - valueDecimals);
+  } else {
+    return value / 10 ** (valueDecimals - toDecimals);
+  }
+}
 
 const incentiveDataInjectSEAMPriceUSD = (
   incentiveData: IncentiveDataHumanized,
@@ -51,6 +63,7 @@ const incentiveDataInjectSEAMPriceUSD = (
   ...incentiveData,
   rewardsTokenInformation: incentiveData.rewardsTokenInformation.map((incentive) => ({
     ...incentive,
+    emissionPerSecond: normalizeDecimals(parseFloat(incentive.emissionPerSecond), incentive.rewardTokenDecimals, 18).toString(),  // Hack to normalize to 18 decimals, since Aave math utils has a bug
     rewardPriceFeed:
       SEAM_SYMBOLS.includes(incentive.rewardTokenSymbol)
         ? seamPriceUSD

--- a/src/store/incentiveSlice.ts
+++ b/src/store/incentiveSlice.ts
@@ -44,18 +44,6 @@ const getCoinGeckoSEAMPriceUSD = async (): Promise<string> => {
   }
 };
 
-function normalizeDecimals(
-  value: number,
-  valueDecimals: number,
-  toDecimals: number
-): number {
-  if (valueDecimals <= toDecimals) {
-    return value * 10 ** (toDecimals - valueDecimals);
-  } else {
-    return value / 10 ** (valueDecimals - toDecimals);
-  }
-}
-
 const incentiveDataInjectSEAMPriceUSD = (
   incentiveData: IncentiveDataHumanized,
   seamPriceUSD: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,9 @@
   dependencies:
     isomorphic-unfetch "^3.1.0"
 
-"@aave/math-utils@1.18.3":
-  version "1.18.3"
-  resolved "https://registry.yarnpkg.com/@aave/math-utils/-/math-utils-1.18.3.tgz#fc21709217f3c4acf8ceb611c93c39ec75780e0e"
-  integrity sha512-+0VtSnlWf7MM7SrPdJXnzvXU6bpjHMh62CVpGYh799tEYf2B1r1FG6ZC0r1cBu6nUF2R+bEmF2kAqs52M2YCmw==
+"@aave/math-utils@https://github.com/seamless-protocol/aave-utilities#math-utils-dist-v1":
+  version "1.28.0"
+  resolved "https://github.com/seamless-protocol/aave-utilities#a1a65b7152ab4594f498ff1dcb705fd97b7ab334"
 
 "@adobe/css-tools@^4.0.1":
   version "4.0.1"


### PR DESCRIPTION
Aave math utils APR calculation assumes all reward tokens have 18 decimals, this is not the case for USDC so I applied a hack to normalize to 18 decimals rather than fork and update the math utils lib since this repo will be deprecated soon.

Resolves #38